### PR TITLE
Add ERC721A

### DIFF
--- a/app/data/landscape.json
+++ b/app/data/landscape.json
@@ -202,8 +202,8 @@
     "launch_year": 2021,
     "logo": "https://raw.githubusercontent.com/chiru-labs/ERC721A/main/docs/assets/img/favicon.png",
     "website": "https://erc721a.org",
-    "github": "https://erc721a.org",
-    "twitter": "",
+    "github": "https://github.com/chiru-labs/ERC721A",
+    "twitter": "https://twitter.com/AzukiOfficial",
     "crunchbase": "",
     "funding": ""
   },

--- a/app/data/landscape.json
+++ b/app/data/landscape.json
@@ -169,6 +169,19 @@
     "funding": ""
   },
   {
+    "description": "ERC721A is an improved implementation of the IERC721 standard that supports minting multiple tokens for close to the cost of one.",
+    "name": "ERC721A",
+    "full_name": "ERC721A",
+    "category": "Open-source libraries",
+    "launch_year": 2021,
+    "logo": "https://raw.githubusercontent.com/chiru-labs/ERC721A/main/docs/assets/img/favicon.png",
+    "website": "https://erc721a.org",
+    "github": "https://github.com/chiru-labs/ERC721A",
+    "twitter": "https://twitter.com/AzukiOfficial",
+    "crunchbase": "",
+    "funding": ""
+  },
+  {
     "description": "Dappsys is a collection of building blocks for building smart contract systems. They are written in Solidity, but deployed objects can be linked to any language.",
     "name": "Dappsys",
     "full_name": "Dappsys",
@@ -191,19 +204,6 @@
     "website": "https://github.com/HQ20/contracts",
     "github": "https://github.com/HQ20/contracts",
     "twitter": "",
-    "crunchbase": "",
-    "funding": ""
-  },
-  {
-    "description": "ERC721A is an improved implementation of the IERC721 standard that supports minting multiple tokens for close to the cost of one.",
-    "name": "ERC721A",
-    "full_name": "ERC721A",
-    "category": "Open-source libraries",
-    "launch_year": 2021,
-    "logo": "https://raw.githubusercontent.com/chiru-labs/ERC721A/main/docs/assets/img/favicon.png",
-    "website": "https://erc721a.org",
-    "github": "https://github.com/chiru-labs/ERC721A",
-    "twitter": "https://twitter.com/AzukiOfficial",
     "crunchbase": "",
     "funding": ""
   },

--- a/app/data/landscape.json
+++ b/app/data/landscape.json
@@ -195,6 +195,19 @@
     "funding": ""
   },
   {
+    "description": "ERC721A is an improved implementation of the IERC721 standard that supports minting multiple tokens for close to the cost of one.",
+    "name": "ERC721A",
+    "full_name": "ERC721A",
+    "category": "Open-source libraries",
+    "launch_year": 2021,
+    "logo": "https://raw.githubusercontent.com/chiru-labs/ERC721A/main/docs/assets/img/preview.png",
+    "website": "https://erc721a.org",
+    "github": "https://erc721a.org",
+    "twitter": "",
+    "crunchbase": "",
+    "funding": ""
+  },
+  {
     "description": "The ethers.js library aims to be a complete and compact library for interacting with the Ethereum Blockchain and its ecosystem.",
     "name": "Ethers.js",
     "full_name": "Ethers.js",

--- a/app/data/landscape.json
+++ b/app/data/landscape.json
@@ -200,7 +200,7 @@
     "full_name": "ERC721A",
     "category": "Open-source libraries",
     "launch_year": 2021,
-    "logo": "https://raw.githubusercontent.com/chiru-labs/ERC721A/main/docs/assets/img/preview.png",
+    "logo": "https://raw.githubusercontent.com/chiru-labs/ERC721A/main/docs/assets/img/favicon.png",
     "website": "https://erc721a.org",
     "github": "https://erc721a.org",
     "twitter": "",


### PR DESCRIPTION
ERC721A is an improved implementation of the ERC721 standard that supports minting multiple tokens for close to the cost of one.

Used across many high profile and most recent NFT projects for scalable minting and gas savings. 

Partially responsible for the renaissance of NFTs on ETH in 2021, and the drop in overall network gas fees in 2021.

Probably responsible, albeit accidentally, for the alt L1 crash by making NFT minting affordable again on the most prestigious smart contract blockchain.

https://github.com/chiru-labs/ERC721A
